### PR TITLE
fix(config): drop the codex tab from the default configuration

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -43,51 +43,22 @@ pub struct TabSessions {
     pub sessions: Vec<SessionData>,
 }
 
-/// Legacy config format for migration
-#[derive(Debug, Clone, Deserialize)]
-struct LegacyPaneConfig {
-    command: String,
-    args: Vec<String>,
-    cwd: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct LegacyAppConfig {
-    left: LegacyPaneConfig,
-    right: LegacyPaneConfig,
-}
-
-fn cli_kind_from_command(command: &str) -> String {
-    if command.to_lowercase().contains("codex") {
-        "codex".to_string()
-    } else if command.to_lowercase().contains("gemini") {
-        "gemini".to_string()
-    } else {
-        "claude".to_string()
-    }
-}
-
 impl Default for AppConfig {
     fn default() -> Self {
+        // One vendor, by decision rather than by omission: the room is built
+        // on a channel capability only this CLI is known to have, and the
+        // spec drops the second vendor to keep that premise out of the
+        // design. Shipping a tab that cannot join the room by default would
+        // present a session that never speaks. See docs/0-requirements.md.
         AppConfig {
-            tabs: vec![
-                TabConfig {
-                    id: "tab-1".to_string(),
-                    name: "Claude Code".to_string(),
-                    command: "claude".to_string(),
-                    args: vec![],
-                    cwd: None,
-                    cli_kind: "claude".to_string(),
-                },
-                TabConfig {
-                    id: "tab-2".to_string(),
-                    name: "Codex".to_string(),
-                    command: "codex".to_string(),
-                    args: vec![],
-                    cwd: None,
-                    cli_kind: "codex".to_string(),
-                },
-            ],
+            tabs: vec![TabConfig {
+                id: "tab-1".to_string(),
+                name: "Claude Code".to_string(),
+                command: "claude".to_string(),
+                args: vec![],
+                cwd: None,
+                cli_kind: "claude".to_string(),
+            }],
         }
     }
 }
@@ -109,41 +80,12 @@ pub fn load_config(app: AppHandle) -> Result<AppConfig, String> {
     let content =
         std::fs::read_to_string(&path).map_err(|e| format!("Failed to read config: {e}"))?;
 
-    // Try parsing as new format first
-    if let Ok(config) = serde_json::from_str::<AppConfig>(&content) {
-        return Ok(config);
-    }
-
-    // Fall back to legacy left/right format and migrate
-    if let Ok(legacy) = serde_json::from_str::<LegacyAppConfig>(&content) {
-        let migrated = AppConfig {
-            tabs: vec![
-                TabConfig {
-                    id: "tab-1".to_string(),
-                    name: "Claude Code".to_string(),
-                    command: legacy.left.command.clone(),
-                    args: legacy.left.args,
-                    cwd: legacy.left.cwd,
-                    cli_kind: cli_kind_from_command(&legacy.left.command),
-                },
-                TabConfig {
-                    id: "tab-2".to_string(),
-                    name: "Codex".to_string(),
-                    command: legacy.right.command.clone(),
-                    args: legacy.right.args,
-                    cwd: legacy.right.cwd,
-                    cli_kind: cli_kind_from_command(&legacy.right.command),
-                },
-            ],
-        };
-        // Save migrated config
-        if let Ok(json) = serde_json::to_string_pretty(&migrated) {
-            let _ = std::fs::write(&path, json);
-        }
-        return Ok(migrated);
-    }
-
-    Err("Failed to parse config: unrecognized format".to_string())
+    // No legacy migration path exists. liplus-chat has never shipped a
+    // release, and its app data directory is keyed to its own identifier
+    // (org.liplus-project.liplus-chat), so no config in the older
+    // left/right pane format from liplus-desktop can reach this app.
+    serde_json::from_str::<AppConfig>(&content)
+        .map_err(|e| format!("Failed to parse config: {e}"))
 }
 
 #[tauri::command]


### PR DESCRIPTION
Closes #13

## 変更内容

- 既定設定を Claude Code 1 タブに変更（Codex タブを削除）
- left/right ペイン形式からの legacy migration を削除
- migration からのみ呼ばれていた `cli_kind_from_command` を削除

## 既定タブ

部屋は Claude 側にしか存在が確認されていない channel capability の上に成り立っており、`docs/0-requirements.md` はその未検証前提を消すために単一ベンダー構成を選んでいる。既定で Codex タブを出すと、部屋へ参加できないセッションを既定で提示することになる。

## legacy migration の扱い（#13 完了条件）

**削除**を選んだ。到達不能なため。

- liplus-chat は一度もリリースされていない（release 0 件、tag 0 件）。
- app data ディレクトリは identifier で決まる。liplus-chat は `org.liplus-project.liplus-chat`、liplus-desktop は `org.liplus-project.liplus-desktop`。
- したがって liplus-desktop の旧 left/right 形式 config がこのアプリの `load_config` に届く経路が存在しない。

残しても migration が効いているかを確かめる手段がない分岐であり、`load_config` は新形式のパース失敗をそのままエラーとして返す形にした。判断の理由はコード側のコメントにも残している。

## 影響範囲

初回起動時の既定タブが 2 件から 1 件になる。保存済み `config.json` は読み込み経路が変わらないため影響を受けない（そもそも保存済み config を持つユーザーは存在しない）。

## 別途観測したもの

`TabConfig.cli_kind` は、legacy migration の削除により `"claude"` の代入以外に書き手も読み手も無くなった。フロントエンドの型定義には残っているが参照されていない。本 PR の目的から外れるため #17 として分離した。

## release type

patch — 既定値の変更と到達不能コードの削除。仕様との矛盾の解消であり、構造変更としては小さい。
