### PR TITLE
fix(sidecar): stop prefixing the speaker into the channel content

### DIFF
--- a/sidecar/src/index.ts
+++ b/sidecar/src/index.ts
@@ -196,7 +196,10 @@ function pushToChannel(frame: SayFrame): void {
   void mcp.notification({
     method: "notifications/claude/channel",
     params: {
-      content: `${user}: ${content}`,
+      // Body only. The speaker rides in meta, which the host renders itself —
+      // putting the name here too produced "マスター: マスター: ハロ～" (#28),
+      // and it leaves the body no longer equal to what was said.
+      content,
       meta: {
         chat_id: CHAT_ID,
         message_id: frame.message_id ?? randomUUID(),

--- a/sidecar/test/round-trip.test.mjs
+++ b/sidecar/test/round-trip.test.mjs
@@ -179,7 +179,9 @@ test("room say reaches the channel, and say_to_room reaches the room", async (t)
   );
 
   const pushed = await nextNotification("notifications/claude/channel");
-  assert.match(pushed.params.content, /Master: 聞こえる？/);
+  // Body only: the speaker belongs in meta, and the host renders it. Mixing it
+  // into the body showed the name twice on screen (#28).
+  assert.equal(pushed.params.content, "聞こえる？");
   assert.equal(pushed.params.meta.chat_id, "test-room");
   assert.equal(pushed.params.meta.message_id, "m-1");
   assert.equal(pushed.params.meta.user, "Master");


### PR DESCRIPTION
Closes #28

## 観測（実機、2026-08-21）

```
liplus-chat-room · マスター: マスター: ハロ～
```

## 原因

`pushToChannel` が `params.content` を `${user}: ${content}` として組み立てる一方、`params.meta.user` にも同じ名前を入れていた。ホストは channel source と `meta.user` を自分で描画するため、`content` へ混ぜた名前が二つ目として現れる。

発言者はメタデータで運ぶものであって本文へ混ぜるものではない。混ぜると本文が発言そのものでなくなり、エージェントが引用や解析をするときに名前が本文の一部として扱われる。

参照実装（`github-webhook-mcp` `local-mcp/src/index.ts`）が `content` に要約文字列を組み立てているのは、あちらが webhook イベントという**発言者のいない通知**を扱っているため。発言者のある会話でそのまま真似たのが誤りだった。

## 変更

`content` を本文のみに。テストは `assert.match` から `assert.equal` へ変えた。部分一致では名前の混入を検出できない——実際、従来のテストは混入したまま通っていた。

## 検証

- `npm run sidecar:check` / `npm run sidecar:test`（pass 1 / fail 0）

## release type

patch — 表示の誤りの修正。