### PR TITLE
ci: move the deprecated node20 actions to their current majors

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,15 +10,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -27,7 +27,7 @@ jobs:
           key: rust-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: rust-${{ runner.os }}-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: node_modules
           key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   check:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
 
@@ -23,7 +23,7 @@ jobs:
       - name: Set GNU as default host
         run: rustup set default-host x86_64-pc-windows-gnu
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -33,7 +33,7 @@ jobs:
           key: rust-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: rust-${{ runner.os }}-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: node_modules
           key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
## 影響範囲

CI/CD ワークフローのみ。`.github/workflows/ci.yml` と `.github/workflows/cd.yml` の `actions/*` の版を上げる。アプリケーションのコード・依存・ビルド構成には触れていない。

## 変更

| action | 変更前 | 変更後 |
|---|---|---|
| `actions/checkout` | `v4` | `v7` |
| `actions/setup-node` | `v4` | `v7` |
| `actions/cache` | `v4` | `v6` |

いずれも Node.js 20 を対象としており、GitHub 側が Node.js 24 で強制実行したうえで毎回 deprecation の annotation を出していた。強制実行は猶予であって恒久的な互換保証ではないため、猶予が切れる前に版を上げる。

`dtolnay/rust-toolchain@stable` はブランチ参照のため対象外。`tauri-apps/tauri-action@v0` は Node の deprecation とは別軸のため #37 に分ける。

## 制約の遵守

- 版のみを変更し、ステップの構成・キャッシュキー・`node-version` は変えていない。同時に動かすと、CI が落ちたときに原因が版なのか構成なのか切り分けられなくなるため。
- ci.yml と cd.yml を同じ PR に含め、同じ action の版が二つのワークフローで食い違う状態を残していない。

## 検証

- 移行先の 3 つの major タグが上流に実在することを確認した（`actions/checkout@v7` / `actions/setup-node@v7` / `actions/cache@v6`）。
- `setup-node` の自動キャッシュは `package.json` に `packageManager` フィールドがあるときに作動する。この repo には当該フィールドが無いことを確認済みで、`node_modules` を明示的に持つ既存の `actions/cache` ステップとは衝突しない。
- `checkout` v7 の fork PR ブロックは `pull_request_target` / `workflow_run` が対象。ci.yml は `push` / `pull_request`、cd.yml は `release` 発火のため当たらない。
- runner の最低版要件は GitHub ホストの `windows-latest` / `ubuntu-latest` のみを使っているため問題にならない。
- cd.yml は release 発火のためこの PR の CI では実行されない。検証は ci.yml の実走と、cd.yml の `actions/*` が ci.yml と同じ版に揃っていることの差分確認による。

Closes #36
