### PR TITLE
fix(room): a lagging participant keeps receiving posts (room delivery pump)

### DIFF
--- a/src-tauri/src/room.rs
+++ b/src-tauri/src/room.rs
@@ -227,6 +227,23 @@ struct RoomInner {
     floor: Floor,
 }
 
+/// The name whoever is on `origin` answers to, or `None` when no one is seated
+/// there yet.
+///
+/// Takes the seat table rather than a `RoomState`, and the delivery pump in
+/// `serve_participant` is the whole reason: `RoomState` carries the fan-out
+/// `Sender` beside the `Arc`, not inside it, so holding one to read a name
+/// would hold a sender too. Read for logging only. Nothing branches on it, and
+/// nothing may: a name is not the identity here (#40), so this is the readable
+/// half of a handle whose other half is the connection id.
+fn name_on(seats: &Mutex<RoomInner>, origin: &str) -> Option<String> {
+    seats
+        .lock()
+        .participants
+        .get(origin)
+        .map(|seat| seat.name.clone())
+}
+
 /// Shared handle to the room socket. Cloneable; all clones share one room.
 #[derive(Clone)]
 pub struct RoomState {
@@ -305,20 +322,6 @@ impl RoomState {
             .participants
             .get(origin)
             .and_then(|seat| seat.account.clone())
-    }
-
-    /// The name whoever is on `origin` answers to, or `None` when no one is
-    /// seated there yet.
-    ///
-    /// Read for logging only. Nothing branches on it, and nothing may: a name
-    /// is not the identity here (#40), so this is the readable half of a
-    /// handle whose other half is the connection id.
-    fn name_of(&self, origin: &str) -> Option<String> {
-        self.inner
-            .lock()
-            .participants
-            .get(origin)
-            .map(|seat| seat.name.clone())
     }
 
     fn set_port(&self, port: u16) {
@@ -597,10 +600,18 @@ async fn serve_participant(
 
     let mut from_room = room.to_participants.subscribe();
     let own_origin = origin.clone();
-    // Held by the pump for one purpose: naming this connection in the lag log
-    // below. The room outlives the pump, and a clone is a handle to the same
-    // room, so this adds no lifetime to anything.
-    let log_room = room.clone();
+    // The seat table alone, for one purpose: naming this connection in the lag
+    // log below.
+    //
+    // Deliberately not `room.clone()`. `RoomState` holds `to_participants` as
+    // a plain field beside `inner`, not inside the `Arc`, so cloning the room
+    // clones the `Sender` — and a pump that owns a sender can never see its own
+    // channel close. `RecvError::Closed` means every sender is gone, so the
+    // `Closed` arm below would be unreachable and the pump would sit in `recv`
+    // forever after the room is torn down, holding the socket task with it.
+    // The seat table cannot do that: `RoomInner` is a port, a `BTreeMap` of
+    // seats and the floor, and no sender lives under it.
+    let seats = Arc::clone(&room.inner);
     let pump = tokio::spawn(async move {
         loop {
             let fanout = match from_room.recv().await {
@@ -636,7 +647,7 @@ async fn serve_participant(
                     // name unusable as an identity in the first place (#40).
                     // Before `hello` there is no name, and the id alone still
                     // identifies the connection.
-                    let seated = log_room.name_of(&own_origin);
+                    let seated = name_on(&seats, &own_origin);
                     let who = seated.as_deref().unwrap_or("(not yet seated)");
                     eprintln!(
                         "[room] \"{who}\" ({own_origin}) fell behind: {dropped} post(s) dropped, delivery continues"

--- a/src-tauri/src/room.rs
+++ b/src-tauri/src/room.rs
@@ -307,6 +307,20 @@ impl RoomState {
             .and_then(|seat| seat.account.clone())
     }
 
+    /// The name whoever is on `origin` answers to, or `None` when no one is
+    /// seated there yet.
+    ///
+    /// Read for logging only. Nothing branches on it, and nothing may: a name
+    /// is not the identity here (#40), so this is the readable half of a
+    /// handle whose other half is the connection id.
+    fn name_of(&self, origin: &str) -> Option<String> {
+        self.inner
+            .lock()
+            .participants
+            .get(origin)
+            .map(|seat| seat.name.clone())
+    }
+
     fn set_port(&self, port: u16) {
         self.inner.lock().port = Some(port);
     }
@@ -583,8 +597,53 @@ async fn serve_participant(
 
     let mut from_room = room.to_participants.subscribe();
     let own_origin = origin.clone();
+    // Held by the pump for one purpose: naming this connection in the lag log
+    // below. The room outlives the pump, and a clone is a handle to the same
+    // room, so this adds no lifetime to anything.
+    let log_room = room.clone();
     let pump = tokio::spawn(async move {
-        while let Ok(fanout) = from_room.recv().await {
+        loop {
+            let fanout = match from_room.recv().await {
+                Ok(fanout) => fanout,
+                // No sender left: the room itself is gone, so nothing further
+                // will ever arrive. Leaving is all there is to do.
+                Err(broadcast::error::RecvError::Closed) => break,
+                // This connection read more slowly than the room spoke, and the
+                // channel overwrote posts it had not taken yet. The receiver is
+                // still live — tokio advances its cursor to the oldest post the
+                // channel still holds and the next `recv` returns that one — so
+                // a lag is a gap, not an ending, and the pump stays.
+                //
+                // Leaving here is what made a momentary gap permanent: the
+                // socket stayed open and the participant stayed on the roster,
+                // so a participant who was never spoken to again looked exactly
+                // like one with nothing to hear. Nothing on the screen or in
+                // the roster could show the difference, which is why this arm
+                // continues and why it logs (#42).
+                //
+                // The dropped posts are not resent. The room keeps no history
+                // to resend from, and giving it one here would put the room in
+                // possession of who heard what — the property the fan-out is
+                // built to avoid holding. A participant who missed posts still
+                // learns of them on their own next post: the floor refuses a
+                // post whose `last_seen` is behind and hands the missed ones
+                // back (#47). That path is the speaker's, not the room's.
+                Err(broadcast::error::RecvError::Lagged(dropped)) => {
+                    // Named by both halves on purpose. The name is what a
+                    // reader recognises and what every other line in this file
+                    // logs; the connection id is what tells two participants
+                    // sharing one name apart, which is the case that made the
+                    // name unusable as an identity in the first place (#40).
+                    // Before `hello` there is no name, and the id alone still
+                    // identifies the connection.
+                    let seated = log_room.name_of(&own_origin);
+                    let who = seated.as_deref().unwrap_or("(not yet seated)");
+                    eprintln!(
+                        "[room] \"{who}\" ({own_origin}) fell behind: {dropped} post(s) dropped, delivery continues"
+                    );
+                    continue;
+                }
+            };
             match &fanout.target {
                 // Addressed to one connection: the room answering whoever
                 // posted. Everyone else's socket is not part of that exchange.


### PR DESCRIPTION
## 変更概要

`src-tauri/src/room.rs` の `serve_participant` 内の配送ポンプを `while let Ok(..)` から `loop` + `match` へ置き換え、`broadcast::error::RecvError` の二つの variant を分けて扱う形にした。

- `Closed` — 従来どおり離脱。送り手がもう居らず、以後何も届かない。
- `Lagged(n)` — 継続。取りこぼした件数を stderr へ出す。

`RoomState::name_of` を追加した。ログに参加者の名前を出すためだけの読み出しであり、`hue_of` / `account_of` と同じ形である。判定には使わない。

## 意図・背景

`while let Ok(..)` は `recv()` の `Err` すべてで抜けるため、`Lagged` でもポンプが恒久的に終了していた。tokio 1.53.1 の broadcast は `Lagged` を返しても receiver を切らず、カーソルをチャンネルが保持している最も古い値へ進めるだけである（`src/sync/broadcast.rs`）。したがって離脱は取りこぼしに対する過剰な反応であり、一時的な遅れが恒久的な無音になっていた。

ソケットは開いたままで席も名簿に残るため、外からは「二度と話しかけられない参加者」と「聞くことが無い参加者」が区別できない。画面にも名簿にも手がかりが出ないため、ログが唯一の観測点である。

## ログの形

```
[room] "<name>" (<origin>) fell behind: <n> post(s) dropped, delivery continues
```

名前と接続 id の両方を出している。名前はこのファイルの他のログ行が使っている読める側の handle であり、接続 id は同名の 2 参加者を分ける側である（名前が同一性ではない理由は #40）。`hello` の前は名前が無いため `(not yet seated)` を置く。その場合も id だけで接続は特定できる。

## 変更していないもの

- sink への送信失敗（`is_err()`）による離脱。相手のソケットが死んでいる場合であり、`Lagged` とは別の軸である。
- `match &fanout.target` の宛先判定。自分の発言の抑止も宛先指定の扱いもそのままである。
- 落ちた発言の再送は行わない。部屋は履歴を持たない設計であり、ここで持たせると「誰が何を聞いたか」を部屋が持つことになる。取りこぼした参加者は自分の次の投稿で床に弾かれ、見ていない発言を受け取る（#47）。それは発言者側の経路であって部屋の経路ではない。

## docs

`docs/0-requirements.md` は更新していない。配送ポンプの受信側エラー処理・broadcast のチャンネル容量・lag 時の挙動について同ファイルに記述が無く、今回の変更が対応する記述が存在しないためである（`lag` / `broadcast` / `取りこぼし` / `容量` / `256` で grep 済み。`broadcast` の語は本文に現れない）。無い記述を今回新設はしていない。

## 検証

- `cargo check`（worktree、`src-tauri`）— pass。新規の warning 無し。
- `npm run build` — pass。

Closes #42
